### PR TITLE
Fix cache ttl refs #12

### DIFF
--- a/app/InputPeriod.php
+++ b/app/InputPeriod.php
@@ -45,6 +45,12 @@ class InputPeriod extends Model implements Period
             ->where('end_at', '>', $now);
     }
 
+    public function scopeComing($query)
+    {
+        $now = date('Y-m-d H:i:s');
+        return $query->where('start_at', '>', $now);
+    }
+
     /**
      * @return boolean
      */

--- a/app/OutsideOfInputPeriod.php
+++ b/app/OutsideOfInputPeriod.php
@@ -4,6 +4,9 @@ namespace App;
 
 class OutsideOfInputPeriod implements Period
 {
+    /** @var \Carbon\Carbon */
+    public $end_at;
+
     /**
      * @return boolean
      * @see Period

--- a/tests/TimelineTest.php
+++ b/tests/TimelineTest.php
@@ -81,4 +81,27 @@ class TimelineTest extends TestCase
 
         $this->assertContains('ただいまtestの入力期間です', $guide);
     }
+
+    /**
+     * 現在入力期間外である場合に、次の入力期間があれば、
+     * currentPeriod() は OutsideOfInputPeriod を返し、
+     * OutsideOfInputPeriod の end_at は次の InputPeriod の start_at になる
+     */
+    public function testEndAt()
+    {
+        $now = Carbon::now();
+        $inputPeriod = new InputPeriod();
+        $inputPeriod->id = 1;
+        $inputPeriod->name = 'test';
+        $inputPeriod->start_at = $now->copy()->addDay();
+        $inputPeriod->end_at = $now->copy()->addDays(2);
+
+        $mockInputPeriod = Mockery::mock('App\InputPeriod')->makePartial();
+        $mockInputPeriod->shouldReceive('current->first')->andReturn(null);
+        $mockInputPeriod->shouldReceive('coming->first')->andReturn($inputPeriod);
+
+        $timeline = new Timeline($mockInputPeriod);
+        $this->assertInstanceOf(OutsideOfInputPeriod::class, $timeline->currentPeriod());
+        $this->assertEquals($inputPeriod->start_at, $timeline->currentPeriod()->end_at);
+    }
 }


### PR DESCRIPTION
## やったこと

以下の条件に応じて、キャッシュの残り分数をセットするようにした。

- 現在の期間が入力期間だった場合: キャッシュの残りは end_at までの分数になる
- 現在の期間が入力期間外で次の入力期間が存在する場合: キャッシュの残りは次の入力期間の start_at までの分数になる
- 現在の期間が入力期間外で次の入力期間が存在しない場合: キャッシュは永久
