### PR TITLE
[WIP][admin]チーム管理者を指定できるようにする

### DIFF
--- a/database/migrations/2017_07_23_154722_add_columns_to_teams_table.php
+++ b/database/migrations/2017_07_23_154722_add_columns_to_teams_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddColumnsToTeamsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->unsignedInteger('manager_individuals_id')->nullable()->after('name');
+            $table->foreign('manager_individuals_id')->references('id')->on('individuals');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropForeign('teams_manager_individuals_id_foreign');
+            $table->dropColumn('manager_individuals_id');
+        });
+    }
+}


### PR DESCRIPTION
## 関連ドキュメント

https://github.com/mtmtkj/okr_laravel/issues/24

## 方針

- teamsテーブルにチームを管理する個人IDとして`manager_individuals_id`を追加
- 「そのチームに所属しているメンバーのみがリーダーになれる」という仕様はアプリケーション側で制御して実現する

## この方針を選んだ理由

leadersテーブルを作ってindividual_idとunique制約をかけたteam_idを持たせることも考えたが
下記の理由で却下した。

- テーブル構成が無駄に複雑になる
- 実装も管理も難易度が上がりそう
- メリットが無さそう
  - 個人がチームに所属しているという保証ができるわけでもない

## 特にレビューをお願いしたい箇所

カラム名が分かりにくい気がするので、代案あれば欲しいです。
