### PR TITLE
[admin] Add admin via command

### DIFF
--- a/app/Admin.php
+++ b/app/Admin.php
@@ -7,5 +7,5 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class Admin extends Authenticatable
 {
-    //
+    protected $guarded = ['id'];
 }

--- a/app/Console/Commands/MakeAdminCommand.php
+++ b/app/Console/Commands/MakeAdminCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Admin;
+use App\Individual;
+use App\User;
+use Illuminate\Console\Command;
+
+class MakeAdminCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:make:admin {name} {email}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create admin account';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+        $email = $this->argument('email');
+        $password = bcrypt($this->secret('Enter password'));
+
+        $props = compact('name', 'email', 'password');
+
+        \DB::transaction(function () use ($props) {
+            $user = User::create($props);
+            Individual::create(['user_id' => $user->id]);
+            Admin::create($props);
+        });
+
+        $this->info('your account is successfully created.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\MakeAdminCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -13,7 +14,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        MakeAdminCommand::class,
     ];
 
     /**


### PR DESCRIPTION
#26 

当初は db:seed コマンドでやろうと思ったけど、Email アドレスを Seeder に書けなかったのでコマンドで追加するようにした。

コマンドは以下。

```
$ php artisan app:make:admin {name} {email}
```

パスワード聞かれるので入力すると、users, individuals, admins にレコードが作成される。