### PR TITLE
nodeの最新版でも動くようになったので修正した

### DIFF
--- a/docker-compose/stal/Dockerfile
+++ b/docker-compose/stal/Dockerfile
@@ -45,8 +45,7 @@ RUN yum -y update openssl
 RUN yum-config-manager --enable cr
 RUN yum -y install nodejs npm
 RUN npm install -g n
-RUN n 8.4.0
-RUN npm update -g
+RUN n latest
 
 # 起動時実行コマンド
 CMD ["/sbin/init"]


### PR DESCRIPTION
nでlatest取ってきても動くようになっていたので修正しました。
が、npmを5.6に上げると動かなかったのでnpmは-gでupdateせず、nのアップデートに伴うところまでしか上げていません。